### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: pre-commit
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/kasutera/dotfiles/security/code-scanning/1](https://github.com/kasutera/dotfiles/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the least privilege required. For the steps shown (checkout, setup-python, pre-commit), only read access to repository contents is needed. The best way to fix this is to add the following block at the top level of the workflow file (just below the `name` field and before `on:`):

```yaml
permissions:
  contents: read
```

This ensures that the GITHUB_TOKEN used by the workflow only has read access to repository contents, reducing the risk of accidental or malicious changes. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
