### PR TITLE
Use shellcheck-py for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
       - id: mixed-line-ending
 
   # ShellCheck - シェルスクリプト解析
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.11.0
+  - repo: https://github.com/ryanrhee/shellcheck-py
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         files: \.(sh|bash|zsh)$


### PR DESCRIPTION
## Summary
- replace the Docker-based ShellCheck pre-commit hook with `shellcheck-py`
- keep ShellCheck pinned to version 0.11.0 while removing the Docker runtime requirement

## Test plan
- [x] Run `pre-commit run --all-files`
- [x] Confirm all hooks, including ShellCheck, pass