### PR TITLE
fix: remove stale zsh-autosuggestions submodule entry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "powerlevel10k"]
 	path = powerlevel10k
 	url = https://github.com/romkatv/powerlevel10k.git
-[submodule "zsh-autosuggestions"]
-	path = zsh-autosuggestions
-	url = https://github.com/zsh-users/zsh-autosuggestions.git
 [submodule "zsh-autocomplete"]
 	path = zsh-autocomplete
 	url = https://github.com/marlonrichert/zsh-autocomplete.git


### PR DESCRIPTION
## Summary

- Remove the stale `zsh-autosuggestions` entry from `.gitmodules`.
- Allow Dependabot gitsubmodule updates to process the remaining submodules.

## Reason

The parent repository no longer contains the `zsh-autosuggestions` gitlink, but `.gitmodules` still declared it. The Dependabot submodule job failed with `zsh-autosuggestions not found` and `dependency_file_not_found`, preventing PRs for other submodules.

The unrelated local submodule worktree changes were not included.